### PR TITLE
Seeking clarification on 2023 RISC-V vector patch from Sourceware GDB mailing list 

### DIFF
--- a/core/cmd_file.c
+++ b/core/cmd_file.c
@@ -23,7 +23,7 @@
 
 static int processGdbFileResponseCommands(void);
 /* Send file open request to gdb on behalf of mbed LocalFileSystem.
-
+/* test comment */
     Data Format: Fopen,ff/nn,gg,mm
     
     Where ff is the hex representation of the address of the filename to be opened.


### PR DESCRIPTION
Hi Greg,

I’m Jay,

I recently came across a GDB patch you submitted to the Sourceware mailing list in August 2023 related to RISC-V vector support:
https://www.sourceware.org/pipermail/gdb-patches/2023-August/201475.html

Unfortunately, I noticed that the email address listed there (greg.savin@sifive.com) is no longer active. While looking for another way to reach out, I found your GitHub profile and I hope it’s the same Greg Savin from the patch.

I’ve been some work with your patch, and I just had a quick clarification:
Does the patch enable visibility of RISC-V vector register values during standard debugging operations like:
```c
break main  
run  
si
```
Or is the patch specifically intended to expose vector registers only through commands like:
```c
info reg vector  
info reg $v1
```
I came across your comment mentioning interactive use of the patch via these commands, and I want to confirm if that’s the only scope of its functionality or whether vector registers can also be observed in disassembly/debug output.

Thanks for your time, and apologies for reaching out via this unconventional method. I appreciate any clarification you can offer!

Best regards,
Jaykumar Lokhande


